### PR TITLE
Remove install from build command.

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -3,7 +3,7 @@ description: >
   The sam build command iterates through the functions in your application, looks for a manifest file (such as requirements.txt) that contains the dependencies, and automatically creates deployment artifacts that you can deploy to Lambda using the sam package and sam deploy commands. You can also use sam build in combination with other commands like sam local invoke to test your application locally.
 
   Optionally package for s3 or run locally.
-  
+
   Ensure CLI has been installed before utilizing.
 
 parameters:

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -1,14 +1,12 @@
 description: >
-  build your Lambda source code and generate deployment artifacts that target Lambda's execution environment.
+  Build your Lambda source code and generate deployment artifacts that target Lambda's execution environment.
   The sam build command iterates through the functions in your application, looks for a manifest file (such as requirements.txt) that contains the dependencies, and automatically creates deployment artifacts that you can deploy to Lambda using the sam package and sam deploy commands. You can also use sam build in combination with other commands like sam local invoke to test your application locally.
 
-  Optionally package for s3 or run locally
+  Optionally package for s3 or run locally.
+  
+  Ensure CLI has been installed before utilizing.
 
 parameters:
-  python_version:
-    description: 'If set, this version of Python will be installed and set with pyenv globally. ex: "3.7.0" This is only for the local environment and will not have any effect if use-container is enabled.'
-    type: string
-    default: ""
   validate:
     type: boolean
     default: true
@@ -50,9 +48,6 @@ parameters:
     default: false
 
 steps:
-  - install:
-      python_version: << parameters.python_version >>
-      profile-name: << parameters.profile-name >>
   - when:
       condition: << parameters.validate >>
       steps:

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -54,6 +54,7 @@ steps:
   - checkout
   - install:
       profile-name: << parameters.profile-name >>
+      python_version: << parameters.python_version >>
   - build:
       validate: << parameters.validate >>
       build-dir: << parameters.build-dir >>
@@ -65,7 +66,6 @@ steps:
       use-container: << parameters.use-container >>
       aws-region: << parameters.aws-region >>
       debug: << parameters.debug >>
-      python_version: << parameters.python_version >>
   - steps: << parameters.pre-deploy >>
   - deploy:
       capabilities: << parameters.capabilities >>


### PR DESCRIPTION
### Checklist

- [x ] All new jobs, commands, executors, parameters have descriptions
- [ x] Examples have been added for any significant new features
- [x ] README has been updated, if necessary

### Motivation, issues

Including install in the build command leads to duplicate steps in jobs. Keep these commands separate. To combine commands, use jobs.

### Description

This PR removes the install command from build.
