### PR TITLE
Add parameter overrides in deployment [semver:minor]

### DIFF
--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -26,6 +26,10 @@ parameters:
     type: boolean
     description: Turns on debug logging.
     default: false
+  parameter-overrides:
+    type: string
+    description: AWS CloudFormation parameter overrides encoded as key=value pairs. Use the same format as the AWS CLI.
+    default: ""
 
 steps:
   - run:
@@ -36,5 +40,6 @@ steps:
           --stack-name << parameters.stack-name >> \
           <<# parameters.profile-name >>--profile << parameters.profile-name >><</ parameters.profile-name >> \
           --region $<< parameters.aws-region >> \
-          <<# parameters.debug >>--debug<</ parameters.debug >>
+          <<# parameters.debug >>--debug<</ parameters.debug >> \
+          <<# parameters.parameter-overrides >>--parameter-overrides << parameters.parameter-overrides >><</ parameters.parameter-overrides >>
 

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -50,6 +50,10 @@ parameters:
     type: boolean
     description: Turns on debug logging.
     default: false
+  parameter-overrides:
+    type: string
+    description: AWS CloudFormation parameter overrides encoded as key=value pairs. Use the same format as the AWS CLI.
+    default: ""
 steps:
   - checkout
   - install:
@@ -74,3 +78,4 @@ steps:
       profile-name: << parameters.profile-name >>
       aws-region: << parameters.aws-region >>
       debug: << parameters.debug >>
+      parameter-overrides: << parameters.parameter-overrides >>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
This PR is to close https://github.com/CircleCI-Public/aws-sam-serverless-orb/issues/8.

I need the use of `--parameter-overrides` in SAM to trigger the re-creation of [custom resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html). I've seen others use parameter overrides to configure dev/prod deployments.

### Description
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Add `parameter-overrides` as a parameter in the `deploy` command and also the `deploy` job.

I don't know how to compile and execute these Orb .yml files locally, so I haven't tested them.  I'd be happy to if you can point me to documentation or give any other feedback.