### PR TITLE
[semver:minor] add no-fail-on-empty-changeset parameter

### DIFF
--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -30,7 +30,10 @@ parameters:
     type: string
     description: AWS CloudFormation parameter overrides encoded as key=value pairs. Use the same format as the AWS CLI.
     default: ""
-
+  no-fail-on-empty-changeset:
+    type: boolean
+    description: Specify if deploy command hould return a zero exit code if there are no changes to be made to the stack.
+    default: true
 steps:
   - run:
       command: |
@@ -41,5 +44,6 @@ steps:
           <<# parameters.profile-name >>--profile << parameters.profile-name >><</ parameters.profile-name >> \
           --region $<< parameters.aws-region >> \
           <<# parameters.debug >>--debug<</ parameters.debug >> \
+          <<# parameters.no-fail-on-empty-changeset >>--no-fail-on-empty-changeset<</ parameters.no-fail-on-empty-changeset >> \
           <<# parameters.parameter-overrides >>--parameter-overrides << parameters.parameter-overrides >><</ parameters.parameter-overrides >>
 

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -54,6 +54,10 @@ parameters:
     type: string
     description: AWS CloudFormation parameter overrides encoded as key=value pairs. Use the same format as the AWS CLI.
     default: ""
+  no-fail-on-empty-changeset:
+    type: boolean
+    description: Specify if deploy command hould return a zero exit code if there are no changes to be made to the stack.
+    default: true
 steps:
   - checkout
   - install:
@@ -79,3 +83,4 @@ steps:
       aws-region: << parameters.aws-region >>
       debug: << parameters.debug >>
       parameter-overrides: << parameters.parameter-overrides >>
+      no-fail-on-empty-changeset: << parameters.no-fail-on-empty-changeset >>


### PR DESCRIPTION
The deploy should be idempotent and the fact there are no changes to
the stack shouldn't fail the build. The default is "true".

Fixes #15 