### PR TITLE
Allow parameters to accept env/context variables.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
       # Publish development version(s) of the orb.
       - orb-tools/publish-dev:
           orb-name: circleci/aws-sam-serverless
-          context: orb-publishing # A restricted context containing your private publishing credentials. Will only execute if approved by an authorized user.
+          context: orb-publisher # A restricted context containing your private publishing credentials. Will only execute if approved by an authorized user.
           requires:
             - orb-tools/lint
             - orb-tools/pack
@@ -50,7 +50,7 @@ workflows:
       # dev:${CIRCLE_SHA1:0:7} version of your orb
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
-          context: orb-publishing
+          context: orb-publisher
           requires:
             - orb-tools/publish-dev
 
@@ -63,14 +63,14 @@ workflows:
     jobs:
       # Run any integration tests defined within the `jobs` key.
       - test_local_invoke:
-          context: serverless-framework-orb-testing
+          context: [CPE_ORBS_AWS]
       - sam/deploy:
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           name: deploy-job-test-app
           template: "./sample_test/sam-app/template.yaml"
           stack-name: "orb-deploy-job-test-1"
-          s3-bucket: "orb-testing"
-          context: serverless-framework-orb-testing
+          s3-bucket: "sam-orb-testing"
+          context: [CPE_ORBS_AWS]
           # python_version: "3.7.0" not used in container builds, adds significant time to job
       - sam/deploy:
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
@@ -78,7 +78,7 @@ workflows:
           template: "./sample_test/sam-container/template.yaml"
           stack-name: "orb-deploy-job-test-2"
           image-repositories: $DEMO_IMG_URI
-          context: serverless-framework-orb-testing
+          context: [CPE_ORBS_AWS]
           validate: false
           # python_version: "3.7.0" not used in container builds, adds significant time to job
       # Publish a semver version of the orb. relies on
@@ -91,7 +91,7 @@ workflows:
           orb-name: circleci/aws-sam-serverless
           bot-token-variable: GHI_TOKEN
           bot-user: cpe-bot
-          context: orb-publishing
+          context: orb-publisher
           add-pr-comment: false
           ssh-fingerprints: 12:0a:59:7e:51:fd:ed:24:8b:98:d3:f1:f4:b5:21:a4
           fail-if-semver-not-indicated: true

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -1,6 +1,6 @@
 set -o noglob
 
-set -- "$@" --profile "$SAM_PARAM_PROFILE"
+set -- "$@" --profile "$(eval "echo $SAM_PARAM_PROFILE")"
 
 set -- "$@" --template-file "$(eval "echo $SAM_PARAM_TEMPLATE")"
 

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -2,7 +2,7 @@ set -o noglob
 IFS=', ' read -r -a ARRAY_CAPABILITIES <<< "$SAM_PARAM_CAPABILITIES"
 echo "${ARRAY_CAPABILITIES[@]}"
 set -- "$@" --capabilities "${ARRAY_CAPABILITIES[@]}"
-set -- "$@" --stack-name "$SAM_PARAM_STACK_NAME"
+set -- "$@" --stack-name "$(eval echo "$SAM_PARAM_STACK_NAME")"
 
 TEMP_REGION="\$"$(echo $SAM_PARAM_AWS_REGION)""
 set -- "$@" --region "$(eval "echo $TEMP_REGION")"

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -34,10 +34,10 @@ if [ -n "$SAM_PARAM_S3_BUCKET" ]; then
     if [ -n "$SAM_PARAM_IMAGE_REPO" ]; then
         echo " parameters.image-repository cannot be set if parameters.s3-bucket is also configured. Remove one of these options."
     fi
-    set -- "$@" --s3-bucket "$SAM_PARAM_S3_BUCKET"
+    set -- "$@" --s3-bucket "$(eval "echo $SAM_PARAM_S3_BUCKET")"
 fi
 if [ -n "$SAM_PARAM_PROFILE_NAME" ]; then
-    set -- "$@" --profile "$SAM_PARAM_PROFILE_NAME"
+    set -- "$@" --profile "$(eval echo "$SAM_PARAM_PROFILE_NAME")"
 fi
 if [ -n "$SAM_PARAM_TEMPLATE" ]; then
     set -- "$@" --template-file "$(eval "echo $SAM_PARAM_TEMPLATE")"
@@ -49,6 +49,6 @@ if [ "$SAM_PARAM_PARAMETER_NOFAIL" = 1 ]; then
     set -- "$@" --no-fail-on-empty-changeset
 fi
 if [ -n "$SAM_PARAM_PARAMETER_OVERRIDES" ]; then
-    set -- "$@" --parameter-overrides "$SAM_PARAM_PARAMETER_OVERRIDES"
+    set -- "$@" --parameter-overrides "$(eval "echo $SAM_PARAM_PARAMETER_OVERRIDES")"
 fi
 sam deploy "$@"


### PR DESCRIPTION
Uses the same template as other existing parameters that can accept
shell variables, using the `$(eval echo ...)` construct.

Potentially fixes #27