### PR TITLE
Make configuring AWS CLI optional

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,7 +6,7 @@ description: >
   Repo: https://github.com/CircleCI-Public/aws-serverless-orb"
 
 orbs:
-  aws-cli: circleci/aws-cli@1.3.0
+  aws-cli: circleci/aws-cli@2.0.3
 
 display:
   home_url: https://aws.amazon.com/serverless/sam/

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -9,6 +9,13 @@ parameters:
     description: 'If set, this version of Python will be installed and set with pyenv globally. ex: "3.7.0" This is only for the local environment and will not have any effect if use-container is enabled.'
     type: string
     default: ""
+  setup-aws-cli:
+    description: |
+      If true, AWS CLI will be configured using the following parameters:
+      profile-name, aws-access-key-id, aws-secret-access-key, aws-region,
+      and configure-default-region.
+
+    default: true
   profile-name:
     description: Profile name to be configured.
     type: string
@@ -54,12 +61,16 @@ steps:
             command: |
               pyenv versions
               pyenv global << parameters.python_version >>
-  - aws-cli/setup:
-      profile-name: << parameters.profile-name >>
-      aws-access-key-id: << parameters.aws-access-key-id >>
-      aws-secret-access-key: << parameters.aws-secret-access-key >>
-      aws-region: << parameters.aws-region >>
-      configure-default-region: << parameters.configure-default-region >>
+  - aws-cli/install
+  - when:
+      condition: << parameters.setup-aws-cli >>
+      steps:
+        - aws-cli/setup:
+            profile-name: << parameters.profile-name >>
+            aws-access-key-id: << parameters.aws-access-key-id >>
+            aws-secret-access-key: << parameters.aws-secret-access-key >>
+            aws-region: << parameters.aws-region >>
+            configure-default-region: << parameters.configure-default-region >>
   - run:
       name: Install SAM CLI
       environment:


### PR DESCRIPTION
You might want to use AWS SAM only to run local commands without
deploying. In that case, there's no need to configure the AWS CLI.

This also updates the AWS CLI orb version to latest.