### PR TITLE
feat!: remove aws cli

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   sam: circleci/aws-sam-serverless@dev:<<pipeline.git.revision>>
   orb-tools: circleci/orb-tools@11.1
+  aws-cli: circleci/aws-cli@3.1.3
 filters: &filters
   tags:
     only: /.*/
@@ -12,6 +13,7 @@ jobs:
       image: ubuntu-2004:202101-01
     steps:
       - checkout
+      - aws-cli/setup
       - sam/install:
           version: 1.57.0
       - sam/local-start-api:
@@ -25,6 +27,8 @@ workflows:
           context: [CPE_ORBS_AWS]
           filters: *filters
       - sam/deploy:
+          pre-steps:
+            - aws-cli/setup
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           name: deploy-job-test-app
           template: "./sample_test/sam-app/template.yaml"
@@ -33,6 +37,8 @@ workflows:
           context: [CPE_ORBS_AWS]
           filters: *filters
       - sam/deploy:
+          pre-steps:
+            - aws-cli/setup
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           name: deploy-job-test-container
           template: "./sample_test/sam-container/template.yaml"

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,9 +5,6 @@ description: >
   Learn More: https://aws.amazon.com/serverless/sam/
   Repo: https://github.com/CircleCI-Public/aws-serverless-orb"
 
-orbs:
-  aws-cli: circleci/aws-cli@3.1.3
-
 display:
   home_url: https://aws.amazon.com/serverless/sam/
   source_url: https://github.com/CircleCI-Public/aws-sam-serverless-orb

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,9 +1,7 @@
 version: 2.1
 
 description: >
-  "Build, Test, and Deploy your AWS serverless applications on CircleCI utilizing the AWS Serverless Application Model.
-  Learn More: https://aws.amazon.com/serverless/sam/
-  Repo: https://github.com/CircleCI-Public/aws-serverless-orb"
+  Build, Test, and Deploy your AWS serverless applications on CircleCI utilizing the AWS Serverless Application Model.
 
 display:
   home_url: https://aws.amazon.com/serverless/sam/

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -32,7 +32,7 @@ parameters:
     default: ""
   no-fail-on-empty-changeset:
     type: boolean
-    description: Specify if deploy command hould return a zero exit code if there are no changes to be made to the stack.
+    description: Specify if deploy command should return a zero exit code if there are no changes to be made to the stack.
     default: true
   image-repositories:
     type: string

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,5 +1,5 @@
 description: >
-  Install and configure the AWS CLI and the SAM CLI in one command. Must have IAM credentials set via environment variables.
+  Install the AWS SAM CLI.
 parameters:
   version:
     description: 'SAM CLI version to be installed.'
@@ -9,36 +9,6 @@ parameters:
     description: 'If set, this version of Python will be installed and set with pyenv globally. ex: "3.7.0" This is only for the local environment and will not have any effect if use-container is enabled.'
     type: string
     default: ""
-  profile-name:
-    description: Profile name to be configured.
-    type: string
-    default: default
-  aws-access-key-id:
-    description: |
-      AWS access key id for IAM role. Set this to the name of
-      the environment variable you will use to hold this
-      value, i.e. AWS_ACCESS_KEY.
-    type: env_var_name
-    default: AWS_ACCESS_KEY_ID
-  aws-secret-access-key:
-    description: |
-      AWS secret key for IAM role. Set this to the name of
-      the environment variable you will use to hold this
-      value, i.e. $AWS_SECRET_ACCESS_KEY.
-    type: env_var_name
-    default: AWS_SECRET_ACCESS_KEY
-  aws-region:
-    description: |
-      Env var of AWS region to operate in
-      (defaults to AWS_DEFAULT_REGION)
-    type: env_var_name
-    default: AWS_DEFAULT_REGION
-  configure-default-region:
-    description: >
-      Some AWS actions don't require a region; set this to false if you do not
-      want to store a default region in ~/.aws/config
-    type: boolean
-    default: true
 steps:
   - when:
       condition: << parameters.python_version >>
@@ -54,12 +24,6 @@ steps:
             command: |
               pyenv versions
               pyenv global << parameters.python_version >>
-  - aws-cli/setup:
-      profile-name: << parameters.profile-name >>
-      aws-access-key-id: << parameters.aws-access-key-id >>
-      aws-secret-access-key: << parameters.aws-secret-access-key >>
-      aws-region: << parameters.aws-region >>
-      configure-default-region: << parameters.configure-default-region >>
   - run:
       name: Install SAM CLI
       environment:

--- a/src/examples/build_test_deploy.yml
+++ b/src/examples/build_test_deploy.yml
@@ -3,7 +3,8 @@ description: >
 usage:
   version: 2.1
   orbs:
-    sam: circleci/aws-sam-serverless@3.0
+    sam: circleci/aws-sam-serverless@4.0
+    aws-cli: circleci/aws-cli@3.1
   jobs:
     test_my_api:
       docker:
@@ -14,6 +15,8 @@ usage:
     test_and_deploy:
       jobs:
         - sam/deploy:
+            pre-steps:
+              - aws-cli/setup
             name: deploy-staging
             template: ./path/to/template.yml
             stack-name: staging-stack
@@ -24,6 +27,8 @@ usage:
             requires:
               - deploy-staging
         - sam/deploy:
+            pre-steps:
+              - aws-cli/setup
             name: deploy-production
             template: "./path/to/template.yml"
             stack-name: "production-stack"

--- a/src/examples/deploy_lambda_container.yml
+++ b/src/examples/deploy_lambda_container.yml
@@ -3,7 +3,8 @@ description: >
 usage:
   version: 2.1
   orbs:
-    sam: circleci/aws-sam-serverless@3.0
+    sam: circleci/aws-sam-serverless@4.0
+    aws-cli: circleci/aws-cli@3.1
   jobs:
     test_my_api:
       docker:

--- a/src/examples/install-cli.yml
+++ b/src/examples/install-cli.yml
@@ -3,12 +3,14 @@ description: >
 usage:
   version: 2.1
   orbs:
-    sam: circleci/aws-sam-serverless@3.0
+    sam: circleci/aws-sam-serverless@4.0
+    aws-cli: circleci/aws-cli@3.1
   jobs:
     build_app:
       executor: sam/default
       steps:
         - checkout
+        - aws-cli/setup
         - sam/install
         - run: sam build # run SAM CLI commands directly once the CLI has been installed.
   workflows:

--- a/src/examples/local_test.yml
+++ b/src/examples/local_test.yml
@@ -3,11 +3,13 @@ description: >
 usage:
   version: 2.1
   orbs:
-    sam: circleci/aws-sam-serverless@3.0
+    sam: circleci/aws-sam-serverless@4.0
+    aws-cli: circleci/aws-cli@3.1
   jobs:
     build_and_package:
       executor: sam/default
       steps:
         - checkout
+        - aws-cli/install
         - sam/install
         - sam/local-start-api

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -87,7 +87,6 @@ steps:
   - checkout
   - install:
       version: << parameters.version >>
-      profile-name: << parameters.profile-name >>
       python_version: << parameters.python_version >>
   - build:
       validate: << parameters.validate >>

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,7 +1,37 @@
 #!/bin/bash
 cd /tmp || true
 if [[ $EUID == 0 ]]; then export SUDO=""; else # Check if we are root
-  export SUDO="sudo";
+  export SUDO="sudo"
+fi
+
+# Check if the AWS CLI is installed
+if ! command -v aws &>/dev/null; then
+  echo "AWS CLI could not be found. Please install it before initiating the SAM CLI."
+  echo
+  echo "Use the circleci/aws-cli orb to install the AWS CLI."
+  echo "https://circleci.com/developer/orbs/orb/circleci/aws-sam-serverless#usage-examples"
+  echo
+  echo "Job example:"
+  echo "
+    jobs:
+      build_app:
+        executor: sam/default
+        steps:
+          - checkout
+          - aws-cli/setup
+          - sam/install
+  "
+  echo
+  echo "Workflow example:"
+  echo "
+    workflows:
+      test_and_deploy:
+        jobs:
+          - sam/deploy:
+              pre-steps:
+                - aws-cli/setup
+  "
+  exit 1
 fi
 
 if [[ $SAM_PARAM_VERSION == "latest" ]]; then
@@ -14,5 +44,5 @@ fi
 unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
 $SUDO ./sam-installation/install
 which sam
-echo "export PATH=$PATH:/usr/local/bin/sam" >> "$BASH_ENV"
+echo "export PATH=$PATH:/usr/local/bin/sam" >>"$BASH_ENV"
 sam --version


### PR DESCRIPTION
The user will now need to import the AWS CLI separately, but this will allow for easier and greater control when authenticating with AWS.

This does mean that pre-steps are needed in the deploy job.