### PR TITLE
docs: update orb name and URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# AWS Serverless Orb
-Orb registry: https://circleci.com/orbs/registry/orb/circleci/aws-serverless
+# AWS SAM Serverless Orb
+Orb registry: <https://circleci.com/developer/orbs/orb/circleci/aws-sam-serverless>
 
 **Description:**
 > Easily install and utilize the SAM CLI on CircleCI to build and test your SAM applications.


### PR DESCRIPTION
The name and URL in the README previously referred to the older iteration of this project: https://circleci.com/developer/orbs/orb/circleci/aws-serverless. This PR updates both to avoid confusing and linking to the old orb.