### PR TITLE
refactor!: implement circleci env subst

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -28,10 +28,10 @@ parameters:
     type: boolean
     description: If your functions depend on packages that have natively compiled dependencies, use this flag to build your function inside an AWS Lambda-like Docker container.
     default: true
-  aws-region:
-    type: env_var_name
+  region:
+    type: string
     description: Sets the AWS Region of the service (for example, us-east-1).
-    default: "AWS_DEFAULT_REGION" # set this to aws install region
+    default: "${AWS_DEFAULT_REGION}" # set this to aws install region
   debug:
     type: boolean
     description: Turns on debug logging.
@@ -52,11 +52,11 @@ steps:
   - run:
       name: "Building SAM application"
       environment:
-        SAM_PARAM_TEMPLATE: << parameters.template >>
-        SAM_PARAM_BUILD_DIR: << parameters.build-dir >>
-        SAM_PARAM_BASE_DIR: << parameters.base-dir >>
-        SAM_PARAM_PROFILE: << parameters.profile-name >>
-        SAM_PARAM_CONTAINER: << parameters.use-container >>
-        SAM_PARAM_AWS_REGION: << parameters.aws-region >>
-        SAM_PARAM_DEBUG: << parameters.debug >>
+        ORB_EVAL_TEMPLATE: << parameters.template >>
+        ORB_EVAL_BUILD_DIR: << parameters.build-dir >>
+        ORB_EVAL_BASE_DIR: << parameters.base-dir >>
+        ORB_EVAL_SAM_PROFILE: << parameters.profile-name >>
+        ORB_VAL_USE_CONTAINER: << parameters.use-container >>
+        ORB_EVAL_REGION: << parameters.region >>
+        ORB_VAL_DEBUG: << parameters.debug >>
       command: <<include(scripts/build.sh)>>

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -31,7 +31,7 @@ parameters:
   region:
     type: string
     description: Sets the AWS Region of the service (for example, us-east-1).
-    default: "${AWS_DEFAULT_REGION}" # set this to aws install region
+    default: ${AWS_DEFAULT_REGION}
   debug:
     type: boolean
     description: Turns on debug logging.
@@ -45,7 +45,7 @@ steps:
             name: "Validating SAM template"
             command: |
               sam validate -t << parameters.template >> \
-              --region $<< parameters.aws-region >> \
+              --region << parameters.region >> \
               --profile << parameters.profile-name >> \
               <<# parameters.debug >>--debug<</ parameters.debug >>
 
@@ -55,7 +55,7 @@ steps:
         ORB_EVAL_TEMPLATE: << parameters.template >>
         ORB_EVAL_BUILD_DIR: << parameters.build-dir >>
         ORB_EVAL_BASE_DIR: << parameters.base-dir >>
-        ORB_EVAL_SAM_PROFILE: << parameters.profile-name >>
+        ORB_EVAL_PROFILE_NAME: << parameters.profile-name >>
         ORB_VAL_USE_CONTAINER: << parameters.use-container >>
         ORB_EVAL_REGION: << parameters.region >>
         ORB_VAL_DEBUG: << parameters.debug >>

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -16,12 +16,12 @@ parameters:
     type: string
     description: Select a specific profile from your credential file to get AWS credentials.
     default: "default"
-  aws-region:
+  region:
     description: |
       Env var of AWS region to operate in
       (defaults to AWS_DEFAULT_REGION)
-    type: env_var_name
-    default: AWS_DEFAULT_REGION
+    type: string
+    default: ${AWS_DEFAULT_REGION}
   debug:
     type: boolean
     description: Turns on debug logging.
@@ -46,7 +46,7 @@ parameters:
     type: boolean
     description: Automatically create an Amazon S3 bucket to use for packaging and deploying for non-guided deployments. If you specify the --guided option, then the AWS SAM CLI ignores --resolve-s3. If you specify both the --s3-bucket and --resolve-s3 options, then an error occurs.
     default: false
-  additional-args:
+  arguments:
     type: string
     description: Additional arguments to pass to the deploy command. e.x. (--resolve-image-repos)
     default: ""
@@ -54,16 +54,16 @@ steps:
   - run:
       name: Deploy SAM application
       environment:
-        SAM_PARAM_CAPABILITIES: <<parameters.capabilities>>
-        SAM_PARAM_TEMPLATE: <<parameters.template>>
-        SAM_PARAM_STACK_NAME: <<parameters.stack-name>>
-        SAM_PARAM_PROFILE_NAME: <<parameters.profile-name>>
-        SAM_PARAM_AWS_REGION: <<parameters.aws-region>>
-        SAM_PARAM_DEBUG: <<parameters.debug>>
-        SAM_PARAM_PARAMETER_OVERRIDES: <<parameters.parameter-overrides>>
-        SAM_PARAM_PARAMETER_NOFAIL: <<parameters.no-fail-on-empty-changeset>>
-        SAM_PARAM_IMAGE_REPO: << parameters.image-repositories >>
-        SAM_PARAM_S3_BUCKET: << parameters.s3-bucket >>
-        SAM_PARAM_RESOLVE_S3: << parameters.resolve-s3 >>
-        SAM_PARAM_ADDITIONAL_ARGS: << parameters.additional-args >>
+        ORB_EVAL_CAPABILITIES: <<parameters.capabilities>>
+        ORB_EVAL_TEMPLATE: <<parameters.template>>
+        ORB_EVAL_STACK_NAME: <<parameters.stack-name>>
+        ORB_EVAL_PROFILE_NAME: <<parameters.profile-name>>
+        ORB_EVAL_REGION: <<parameters.aws-region>>
+        ORB_VAL_DEBUG: <<parameters.debug>>
+        ORB_EVAL_OVERRIDES: <<parameters.parameter-overrides>>
+        ORB_VAL_NOFAIL: <<parameters.no-fail-on-empty-changeset>>
+        ORB_EVAL_IMAGE_REPO: << parameters.image-repositories >>
+        ORB_EVAL_S3_BUCKET: << parameters.s3-bucket >>
+        ORB_VAL_RESOLVE_S3: << parameters.resolve-s3 >>
+        ORB_EVAL_ARGUMENTS: << parameters.arguments >>
       command: <<include(scripts/deploy.sh)>>

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -18,7 +18,6 @@ parameters:
     default: "default"
   region:
     description: |
-      Env var of AWS region to operate in
       (defaults to AWS_DEFAULT_REGION)
     type: string
     default: ${AWS_DEFAULT_REGION}
@@ -58,7 +57,7 @@ steps:
         ORB_EVAL_TEMPLATE: <<parameters.template>>
         ORB_EVAL_STACK_NAME: <<parameters.stack-name>>
         ORB_EVAL_PROFILE_NAME: <<parameters.profile-name>>
-        ORB_EVAL_REGION: <<parameters.aws-region>>
+        ORB_EVAL_REGION: <<parameters.region>>
         ORB_VAL_DEBUG: <<parameters.debug>>
         ORB_EVAL_OVERRIDES: <<parameters.parameter-overrides>>
         ORB_VAL_NOFAIL: <<parameters.no-fail-on-empty-changeset>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -27,5 +27,5 @@ steps:
   - run:
       name: Install SAM CLI
       environment:
-        SAM_PARAM_VERSION: << parameters.version >>
+        ORB_EVAL_VERSION: << parameters.version >>
       command: <<include(scripts/install.sh)>>

--- a/src/commands/local-start-api.yml
+++ b/src/commands/local-start-api.yml
@@ -33,20 +33,20 @@ steps:
   - run:
       name: install dockerize
       environment:
-        PARAM_DOCKERIZE_VERSION: <<parameters.dockerize_version>>
+        ORB_EVAL_DOCKERIZE_VERSION: <<parameters.dockerize_version>>
       command: <<include(scripts/install-dockerize.sh)>>
   - run:
       name: SAM local start-api
       background: true
       environment:
-        PARAM_DEBUG: <<parameters.debug>>
-        PARAM_TEMPLATE: <<parameters.template>>
-        PARAM_PORT: <<parameters.port>>
-        PARAM_ENV_VARS: <<parameters.env-vars>>
+        ORB_VAL_DEBUG: <<parameters.debug>>
+        ORB_EVAL_TEMPLATE: <<parameters.template>>
+        ORB_VAL_PORT: <<parameters.port>>
+        ORB_EVAL_ENV_VARS: <<parameters.env-vars>>
       command: <<include(scripts/local-start-api.sh)>>
   - run:
       name: Wait for API
       environment:
-        PARAM_ENDPOINT: <<parameters.endpoint>>
-        PARAM_TIMEOUT: <<parameters.timeout>>
+        ORB_EVAL_ENDPOINT: <<parameters.endpoint>>
+        ORB_VAL_TIMEOUT: <<parameters.timeout>>
       command: <<include(scripts/dockerize-wait.sh)>>

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -101,14 +101,14 @@ steps:
       template: << parameters.template >>
       profile-name: << parameters.profile-name >>
       use-container: << parameters.use-container >>
-      aws-region: << parameters.aws-region >>
+      region: << parameters.region >>
       debug: << parameters.debug >>
   - steps: << parameters.pre-deploy >>
   - deploy:
       capabilities: << parameters.capabilities >>
       stack-name: << parameters.stack-name >>
       profile-name: << parameters.profile-name >>
-      aws-region: << parameters.aws-region >>
+      region: << parameters.region >>
       debug: << parameters.debug >>
       parameter-overrides: << parameters.parameter-overrides >>
       no-fail-on-empty-changeset: << parameters.no-fail-on-empty-changeset >>

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -60,10 +60,10 @@ parameters:
     type: boolean
     description: If your functions depend on packages that have natively compiled dependencies, use this flag to build your function inside an AWS Lambda-like Docker container.
     default: true
-  aws-region:
-    type: env_var_name
+  region:
+    type: string
     description: Sets the AWS Region of the service (for example, us-east-1).
-    default: "AWS_DEFAULT_REGION" # set this to aws install region
+    default: ${AWS_DEFAULT_REGION} # set this to aws install region
   stack-name:
     type: string
     description: The name of the AWS CloudFormation stack you're deploying to. If you specify an existing stack, the command updates the stack. If you specify a new stack, the command creates it.
@@ -79,7 +79,7 @@ parameters:
     type: boolean
     description: Specify if deploy command hould return a zero exit code if there are no changes to be made to the stack.
     default: true
-  additional-args:
+  arguments:
     type: string
     description: Additional arguments to pass to the deploy command. e.x. (--resolve-image-repos)
     default: ""
@@ -115,4 +115,4 @@ steps:
       image-repositories: << parameters.image-repositories >>
       s3-bucket: << parameters.s3-bucket >>
       resolve-s3: << parameters.resolve-s3 >>
-      additional-args: << parameters.additional-args >>
+      arguments: << parameters.arguments >>

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -o noglob
 
-set -- "$@" --template-file "$(eval "echo $ORB_EVAL_TEMPLATE")"
+set -- "$@" --template-file "$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
 
 set -- "$@" --region "${ORB_EVAL_REGION}"
 
 if [ -n "$ORB_EVAL_BUILD_DIR" ]; then
-  set -- "$@" --build-dir "$(eval "echo $ORB_EVAL_BUILD_DIR")"
+  set -- "$@" --build-dir "$(circleci env subst "${ORB_EVAL_BUILD_DIR}")"
 fi
 if [ -n "$ORB_EVAL_BASE_DIR" ]; then
-  set -- "$@" --base-dir "$(eval "echo $ORB_EVAL_BASE_DIR")"
+  set -- "$@" --base-dir "$(circleci env subst "${ORB_EVAL_BASE_DIR}")"
 fi
 if [ "$ORB_VAL_USE_CONTAINER" = 1 ]; then
   set -- "$@" --use-container

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -1,25 +1,23 @@
 #!/bin/bash
 set -o noglob
 
-set -- "$@" --profile "$(eval "echo $SAM_PARAM_PROFILE")"
+set -- "$@" --template-file "$(eval "echo $ORB_EVAL_TEMPLATE")"
 
-set -- "$@" --template-file "$(eval "echo $SAM_PARAM_TEMPLATE")"
+set -- "$@" --region "${ORB_EVAL_REGION}"
 
-set -- "$@" --region "${!SAM_PARAM_AWS_REGION}"
-
-if [ -n "$SAM_PARAM_BUILD_DIR" ]; then
-  set -- "$@" --build-dir "$(eval "echo $SAM_PARAM_BUILD_DIR")"
+if [ -n "$ORB_EVAL_BUILD_DIR" ]; then
+  set -- "$@" --build-dir "$(eval "echo $ORB_EVAL_BUILD_DIR")"
 fi
-if [ -n "$SAM_PARAM_BASE_DIR" ]; then
-  set -- "$@" --base-dir "$(eval "echo $SAM_PARAM_BASE_DIR")"
+if [ -n "$ORB_EVAL_BASE_DIR" ]; then
+  set -- "$@" --base-dir "$(eval "echo $ORB_EVAL_BASE_DIR")"
 fi
-if [ "$SAM_PARAM_CONTAINER" = 1 ]; then
+if [ "$ORB_VAL_USE_CONTAINER" = 1 ]; then
   set -- "$@" --use-container
 fi
-if [ "$SAM_PARAM_DEBUG" = 1 ]; then
+if [ "$ORB_VAL_DEBUG" = 1 ]; then
   set -- "$@" --debug
 fi
 
 set -x
-sam build "$@"
+sam build --profile "${ORB_EVAL_PROFILE_NAME}" "$@"
 set +x

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -o noglob
+ORB_EVAL_REGION="$(circleci env subst "${ORB_EVAL_REGION}")"
 
 set -- "$@" --template-file "$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
 

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 set -o noglob
 ORB_EVAL_REGION="$(circleci env subst "${ORB_EVAL_REGION}")"
+ORB_EVAL_TEMPLATE="$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
+ORB_EVAL_BUILD_DIR="$(circleci env subst "${ORB_EVAL_BUILD_DIR}")"
+ORB_EVAL_BASE_DIR="$(circleci env subst "${ORB_EVAL_BASE_DIR}")"
 
-set -- "$@" --template-file "$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
+set -- "$@" --template-file "${ORB_EVAL_TEMPLATE}"
 
 set -- "$@" --region "${ORB_EVAL_REGION}"
 
 if [ -n "$ORB_EVAL_BUILD_DIR" ]; then
-  set -- "$@" --build-dir "$(circleci env subst "${ORB_EVAL_BUILD_DIR}")"
+  set -- "$@" --build-dir "${ORB_EVAL_BUILD_DIR}"
 fi
 if [ -n "$ORB_EVAL_BASE_DIR" ]; then
-  set -- "$@" --base-dir "$(circleci env subst "${ORB_EVAL_BASE_DIR}")"
+  set -- "$@" --base-dir "${ORB_EVAL_BASE_DIR}"
 fi
 if [ "$ORB_VAL_USE_CONTAINER" = 1 ]; then
   set -- "$@" --use-container

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -1,16 +1,26 @@
 #!/bin/bash
 set -o noglob
-IFS=', ' read -r -a ARRAY_CAPABILITIES <<< "$SAM_PARAM_CAPABILITIES"
+ORB_EVAL_REGION="$(circleci env subst "${ORB_EVAL_REGION}")"
+ORB_EVAL_CAPABILITIES="$(circleci env subst "${ORB_EVAL_CAPABILITIES}")"
+ORB_EVAL_IMAGE_REPO="$(circleci env subst "${ORB_EVAL_IMAGE_REPO}")"
+ORB_EVAL_S3_BUCKET="$(circleci env subst "${ORB_EVAL_S3_BUCKET}")"
+ORB_EVAL_TEMPLATE="$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
+ORB_EVAL_OVERRIDES="$(circleci env subst "${ORB_EVAL_OVERRIDES}")"
+ORB_EVAL_ARGUMENTS="$(circleci env subst "${ORB_EVAL_ARGUMENTS}")"
+
+
+IFS=', ' read -r -a ARRAY_CAPABILITIES <<< "$ORB_EVAL_CAPABILITIES"
 echo "${ARRAY_CAPABILITIES[@]}"
 set -- "$@" --capabilities "${ARRAY_CAPABILITIES[@]}"
-set -- "$@" --stack-name "$(eval echo "$SAM_PARAM_STACK_NAME")"
-
-set -- "$@" --region "${!SAM_PARAM_AWS_REGION}"
+set -- "$@" --stack-name "$(eval echo "$ORB_EVAL_STACK_NAME")"
 
 
-if [ -n "$SAM_PARAM_IMAGE_REPO" ]; then
-    echo "DEBUG: set_image_repos called" "$(eval echo "$SAM_PARAM_IMAGE_REPO")" | tee -a /tmp/sam.log
-    IFS=', ' read -r -a ARRAY_REPOSITORIES <<< "$(eval echo "$SAM_PARAM_IMAGE_REPO")"
+set -- "$@" --region "${ORB_EVAL_REGION}"
+
+
+if [ -n "$ORB_EVAL_IMAGE_REPO" ]; then
+    echo "DEBUG: set_image_repos called" "$(eval echo "$ORB_EVAL_IMAGE_REPO")" | tee -a /tmp/sam.log
+    IFS=', ' read -r -a ARRAY_REPOSITORIES <<< "$(eval echo "$ORB_EVAL_IMAGE_REPO")"
     REPOARRYLEN=${#ARRAY_REPOSITORIES[@]}
     if [ "$REPOARRYLEN" = 1 ]; then
         echo "DEBUG: Single image repo named ${ARRAY_REPOSITORIES[0]}" | tee -a /tmp/sam.log
@@ -24,35 +34,32 @@ if [ -n "$SAM_PARAM_IMAGE_REPO" ]; then
         done
     fi
 fi
-if [ -n "$SAM_PARAM_S3_BUCKET" ]; then
+if [ -n "$ORB_EVAL_S3_BUCKET" ]; then
     # Technically this shouldnt be needed as this shouldnt be possible given the order of execution
-    if [ -n "$SAM_PARAM_IMAGE_REPO" ]; then
+    if [ -n "$ORB_EVAL_IMAGE_REPO" ]; then
         echo " parameters.image-repository cannot be set if parameters.s3-bucket is also configured. Remove one of these options."
     fi
-    set -- "$@" --s3-bucket "$(eval "echo $SAM_PARAM_S3_BUCKET")"
+    set -- "$@" --s3-bucket "$(eval "echo $ORB_EVAL_S3_BUCKET")"
 fi
-if [ -n "$SAM_PARAM_PROFILE_NAME" ]; then
-    set -- "$@" --profile "$(eval echo "$SAM_PARAM_PROFILE_NAME")"
+if [ -n "$ORB_EVAL_TEMPLATE" ]; then
+    set -- "$@" --template-file "$(eval "echo $ORB_EVAL_TEMPLATE")"
 fi
-if [ -n "$SAM_PARAM_TEMPLATE" ]; then
-    set -- "$@" --template-file "$(eval "echo $SAM_PARAM_TEMPLATE")"
-fi
-if [ "$SAM_PARAM_DEBUG" = 1 ]; then
+if [ "$ORB_VAL_DEBUG" = 1 ]; then
     set -- "$@" --debug
 fi
-if [ "$SAM_PARAM_PARAMETER_NOFAIL" = 1 ]; then
+if [ "$ORB_VAL_NOFAIL" = 1 ]; then
     set -- "$@" --no-fail-on-empty-changeset
 fi
-if [ "$SAM_PARAM_RESOLVE_S3" = 1 ]; then
+if [ "$ORB_VAL_RESOLVE_S3" = 1 ]; then
     set -- "$@" --resolve-s3
 fi
-if [ -n "$SAM_PARAM_PARAMETER_OVERRIDES" ]; then
+if [ -n "$ORB_EVAL_OVERRIDES" ]; then
     set -- "$@" --parameter-overrides "$(eval "echo $SAM_PARAM_PARAMETER_OVERRIDES")"
 fi
-if [ -z "$SAM_PARAM_ADDITIONAL_ARGS" ]; then
-    set -- "$@" "$SAM_PARAM_ADDITIONAL_ARGS"
+if [ -z "$ORB_EVAL_ARGUMENTS" ]; then
+    set -- "$@" "$ORB_EVAL_ARGUMENTS"
 fi
 
 set -x
-sam deploy "$@"
+sam deploy --profile "${ORB_EVAL_PROFILE_NAME}" "$@"
 set +x

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -8,6 +8,9 @@ ORB_EVAL_OVERRIDES="$(circleci env subst "${ORB_EVAL_OVERRIDES}")"
 ORB_EVAL_ARGUMENTS="$(circleci env subst "${ORB_EVAL_ARGUMENTS}")"
 ORB_EVAL_REGION="$(circleci env subst "${ORB_EVAL_REGION}")"
 ORB_EVAL_STACK_NAME="$(circleci env subst "${ORB_EVAL_STACK_NAME}")"
+ORB_EVAL_S3_BUCKET="$(circleci env subst "${ORB_EVAL_S3_BUCKET}")"
+ORB_EVAL_TEMPLATE="$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
+ORB_EVAL_OVERRIDES="$(circleci env subst "${ORB_EVAL_OVERRIDES}")"
 
 
 IFS=', ' read -r -a ARRAY_CAPABILITIES <<< "$ORB_EVAL_CAPABILITIES"
@@ -18,8 +21,8 @@ set -- "$@" --region "${ORB_EVAL_REGION}"
 
 
 if [ -n "$ORB_EVAL_IMAGE_REPO" ]; then
-    echo "DEBUG: set_image_repos called" "$(circleci env subst "${ORB_EVAL_IMAGE_REPO}")"| tee -a /tmp/sam.log
-    IFS=', ' read -r -a ARRAY_REPOSITORIES <<< "$(circleci env subst "${ORB_EVAL_IMAGE_REPO}")"
+    echo "DEBUG: set_image_repos called" "${ORB_EVAL_IMAGE_REPO}"| tee -a /tmp/sam.log
+    IFS=', ' read -r -a ARRAY_REPOSITORIES <<< "${ORB_EVAL_IMAGE_REPO}"
     REPOARRYLEN=${#ARRAY_REPOSITORIES[@]}
     if [ "$REPOARRYLEN" = 1 ]; then
         echo "DEBUG: Single image repo named ${ARRAY_REPOSITORIES[0]}" | tee -a /tmp/sam.log
@@ -38,10 +41,10 @@ if [ -n "$ORB_EVAL_S3_BUCKET" ]; then
     if [ -n "$ORB_EVAL_IMAGE_REPO" ]; then
         echo " parameters.image-repository cannot be set if parameters.s3-bucket is also configured. Remove one of these options."
     fi
-    set -- "$@" --s3-bucket "$(circleci env subst "${ORB_EVAL_S3_BUCKET}")"
+    set -- "$@" --s3-bucket "${ORB_EVAL_S3_BUCKET}"
 fi
 if [ -n "$ORB_EVAL_TEMPLATE" ]; then
-    set -- "$@" --template-file "$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
+    set -- "$@" --template-file "${ORB_EVAL_TEMPLATE}"
 fi
 if [ "$ORB_VAL_DEBUG" = 1 ]; then
     set -- "$@" --debug
@@ -53,7 +56,7 @@ if [ "$ORB_VAL_RESOLVE_S3" = 1 ]; then
     set -- "$@" --resolve-s3
 fi
 if [ -n "$ORB_EVAL_OVERRIDES" ]; then
-    set -- "$@" --parameter-overrides "$(circleci env subst "${ORB_EVAL_OVERRIDES}")"
+    set -- "$@" --parameter-overrides "${ORB_EVAL_OVERRIDES}"
 fi
 if [ -z "$ORB_EVAL_ARGUMENTS" ]; then
     set -- "$@" "$ORB_EVAL_ARGUMENTS"

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o noglob
-ORB_EVAL_REGION="$(circleci env subst "${ORB_EVAL_REGION}")"
 ORB_EVAL_CAPABILITIES="$(circleci env subst "${ORB_EVAL_CAPABILITIES}")"
 ORB_EVAL_IMAGE_REPO="$(circleci env subst "${ORB_EVAL_IMAGE_REPO}")"
 ORB_EVAL_S3_BUCKET="$(circleci env subst "${ORB_EVAL_S3_BUCKET}")"

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -6,14 +6,14 @@ ORB_EVAL_S3_BUCKET="$(circleci env subst "${ORB_EVAL_S3_BUCKET}")"
 ORB_EVAL_TEMPLATE="$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
 ORB_EVAL_OVERRIDES="$(circleci env subst "${ORB_EVAL_OVERRIDES}")"
 ORB_EVAL_ARGUMENTS="$(circleci env subst "${ORB_EVAL_ARGUMENTS}")"
+ORB_EVAL_REGION="$(circleci env subst "${ORB_EVAL_REGION}")"
+ORB_EVAL_STACK_NAME="$(circleci env subst "${ORB_EVAL_STACK_NAME}")"
 
 
 IFS=', ' read -r -a ARRAY_CAPABILITIES <<< "$ORB_EVAL_CAPABILITIES"
 echo "${ARRAY_CAPABILITIES[@]}"
 set -- "$@" --capabilities "${ARRAY_CAPABILITIES[@]}"
-set -- "$@" --stack-name "$(circleci env subst "{$ORB_EVAL_STACK_NAME}")"
-
-
+set -- "$@" --stack-name "${ORB_EVAL_STACK_NAME}"
 set -- "$@" --region "${ORB_EVAL_REGION}"
 
 

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -12,15 +12,15 @@ ORB_EVAL_ARGUMENTS="$(circleci env subst "${ORB_EVAL_ARGUMENTS}")"
 IFS=', ' read -r -a ARRAY_CAPABILITIES <<< "$ORB_EVAL_CAPABILITIES"
 echo "${ARRAY_CAPABILITIES[@]}"
 set -- "$@" --capabilities "${ARRAY_CAPABILITIES[@]}"
-set -- "$@" --stack-name "$(eval echo "$ORB_EVAL_STACK_NAME")"
+set -- "$@" --stack-name "$(circleci env subst "{$ORB_EVAL_STACK_NAME}")"
 
 
 set -- "$@" --region "${ORB_EVAL_REGION}"
 
 
 if [ -n "$ORB_EVAL_IMAGE_REPO" ]; then
-    echo "DEBUG: set_image_repos called" "$(eval echo "$ORB_EVAL_IMAGE_REPO")" | tee -a /tmp/sam.log
-    IFS=', ' read -r -a ARRAY_REPOSITORIES <<< "$(eval echo "$ORB_EVAL_IMAGE_REPO")"
+    echo "DEBUG: set_image_repos called" "$(circleci env subst "${ORB_EVAL_IMAGE_REPO}")"| tee -a /tmp/sam.log
+    IFS=', ' read -r -a ARRAY_REPOSITORIES <<< "$(circleci env subst "${ORB_EVAL_IMAGE_REPO}")"
     REPOARRYLEN=${#ARRAY_REPOSITORIES[@]}
     if [ "$REPOARRYLEN" = 1 ]; then
         echo "DEBUG: Single image repo named ${ARRAY_REPOSITORIES[0]}" | tee -a /tmp/sam.log
@@ -39,10 +39,10 @@ if [ -n "$ORB_EVAL_S3_BUCKET" ]; then
     if [ -n "$ORB_EVAL_IMAGE_REPO" ]; then
         echo " parameters.image-repository cannot be set if parameters.s3-bucket is also configured. Remove one of these options."
     fi
-    set -- "$@" --s3-bucket "$(eval "echo $ORB_EVAL_S3_BUCKET")"
+    set -- "$@" --s3-bucket "$(circleci env subst "${ORB_EVAL_S3_BUCKET}")"
 fi
 if [ -n "$ORB_EVAL_TEMPLATE" ]; then
-    set -- "$@" --template-file "$(eval "echo $ORB_EVAL_TEMPLATE")"
+    set -- "$@" --template-file "$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
 fi
 if [ "$ORB_VAL_DEBUG" = 1 ]; then
     set -- "$@" --debug
@@ -54,7 +54,7 @@ if [ "$ORB_VAL_RESOLVE_S3" = 1 ]; then
     set -- "$@" --resolve-s3
 fi
 if [ -n "$ORB_EVAL_OVERRIDES" ]; then
-    set -- "$@" --parameter-overrides "$(eval "echo $SAM_PARAM_PARAMETER_OVERRIDES")"
+    set -- "$@" --parameter-overrides "$(circleci env subst "${ORB_EVAL_OVERRIDES}")"
 fi
 if [ -z "$ORB_EVAL_ARGUMENTS" ]; then
     set -- "$@" "$ORB_EVAL_ARGUMENTS"

--- a/src/scripts/dockerize-wait.sh
+++ b/src/scripts/dockerize-wait.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-dockerize -wait "http://127.0.0.1:3000/${PARAM_ENDPOINT}" -timeout "${PARAM_TIMEOUT}m"
+ORB_EVAL_ENDPOINT="$(circleci env subst "${ORB_EVAL_ENDPOINT}")"
+dockerize -wait "http://127.0.0.1:3000/${ORB_EVAL_ENDPOINT}" -timeout "${ORB_VAL_TIMEOUT}m"

--- a/src/scripts/install-dockerize.sh
+++ b/src/scripts/install-dockerize.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-wget "https://github.com/jwilder/dockerize/releases/download/v${PARAM_DOCKERIZE_VERSION}/dockerize-linux-amd64-v${PARAM_DOCKERIZE_VERSION}.tar.gz" && \
-  sudo tar -C /usr/local/bin -xzvf "dockerize-linux-amd64-v${PARAM_DOCKERIZE_VERSION}.tar.gz" && \
-  rm "dockerize-linux-amd64-v${PARAM_DOCKERIZE_VERSION}.tar.gz"
+ORB_EVAL_DOCKERIZE_VERSION="$(circle env subst "$ORB_EVAL_DOCKERIZE_VERSION")"
+
+wget "https://github.com/jwilder/dockerize/releases/download/v${ORB_EVAL_DOCKERIZE_VERSION}/dockerize-linux-amd64-v${ORB_EVAL_DOCKERIZE_VERSION}.tar.gz" && \
+  sudo tar -C /usr/local/bin -xzvf "dockerize-linux-amd64-v${ORB_EVAL_DOCKERIZE_VERSION}.tar.gz" && \
+  rm "dockerize-linux-amd64-v${ORB_EVAL_DOCKERIZE_VERSION}.tar.gz"

--- a/src/scripts/install-dockerize.sh
+++ b/src/scripts/install-dockerize.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ORB_EVAL_DOCKERIZE_VERSION="$(circle env subst "{$ORB_EVAL_DOCKERIZE_VERSION}")"
+ORB_EVAL_DOCKERIZE_VERSION="$(circleci env subst "${ORB_EVAL_DOCKERIZE_VERSION}")"
 
 wget "https://github.com/jwilder/dockerize/releases/download/v${ORB_EVAL_DOCKERIZE_VERSION}/dockerize-linux-amd64-v${ORB_EVAL_DOCKERIZE_VERSION}.tar.gz" && \
   sudo tar -C /usr/local/bin -xzvf "dockerize-linux-amd64-v${ORB_EVAL_DOCKERIZE_VERSION}.tar.gz" && \

--- a/src/scripts/install-dockerize.sh
+++ b/src/scripts/install-dockerize.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ORB_EVAL_DOCKERIZE_VERSION="$(circle env subst "$ORB_EVAL_DOCKERIZE_VERSION")"
+ORB_EVAL_DOCKERIZE_VERSION="$(circle env subst "{$ORB_EVAL_DOCKERIZE_VERSION}")"
 
 wget "https://github.com/jwilder/dockerize/releases/download/v${ORB_EVAL_DOCKERIZE_VERSION}/dockerize-linux-amd64-v${ORB_EVAL_DOCKERIZE_VERSION}.tar.gz" && \
   sudo tar -C /usr/local/bin -xzvf "dockerize-linux-amd64-v${ORB_EVAL_DOCKERIZE_VERSION}.tar.gz" && \

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -34,12 +34,12 @@ if ! command -v aws &>/dev/null; then
   exit 1
 fi
 
-if [[ $SAM_PARAM_VERSION == "latest" ]]; then
+if [[ $ORB_EVAL_VERSION == "latest" ]]; then
   echo "Installing latest version of SAM CLI"
   curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o aws-sam-cli-linux-x86_64.zip
 else
-  echo "Installing SAM CLI version $SAM_PARAM_VERSION"
-  curl -L "https://github.com/aws/aws-sam-cli/releases/download/v${SAM_PARAM_VERSION}/aws-sam-cli-linux-x86_64.zip" -o aws-sam-cli-linux-x86_64.zip
+  echo "Installing SAM CLI version $ORB_EVAL_VERSION"
+  curl -L "https://github.com/aws/aws-sam-cli/releases/download/v${ORB_EVAL_VERSION}/aws-sam-cli-linux-x86_64.zip" -o aws-sam-cli-linux-x86_64.zip
 fi
 unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
 $SUDO ./sam-installation/install

--- a/src/scripts/local-start-api.sh
+++ b/src/scripts/local-start-api.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
-
-if [ -n "$PARAM_TEMPLATE" ]; then
-  set -- "$@" -t "$PARAM_TEMPLATE"
+ORB_EVAL_TEMPLATE="$(circleci env subst "${ORB_EVAL_TEMPLATE}")"
+ORB_EVAL_ENV_VARS="$(circleci env subst "${ORB_EVAL_ENV_VARS}")"
+if [ -n "$ORB_EVAL_TEMPLATE" ]; then
+  set -- "$@" -t "$ORB_EVAL_TEMPLATE"
 fi
 
-set -- "$@" -p "$PARAM_PORT"
+set -- "$@" -p "$ORB_VAL_PORT"
 
-if [ -n "$PARAM_ENV_VARS" ]; then
+if [ -n "$ORB_EVAL_ENV_VARS" ]; then
   set -- "$@" -n "$PARAM_ENV_VARS"
 fi
 
-if [ "$PARAM_DEBUG" = 1 ]; then
+if [ "$ORB_VAL_DEBUG" = 1 ]; then
   set -- "$@" --debug
 fi
 


### PR DESCRIPTION
This `PR` implements `circleci env subst` as a replacement for `eval`. It also renames orb variables to comply with the Orb Standardization Guide. 