### PR TITLE
fix: remove PATH changes from sam/install to unbreak later `run` commands

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -44,5 +44,4 @@ fi
 unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
 $SUDO ./sam-installation/install
 which sam
-echo "export PATH=$PATH:/usr/local/bin/sam" >>"$BASH_ENV"
 sam --version


### PR DESCRIPTION
At present, any commands run after `sam/install` will fail - at least within the most recent machine image (`ubuntu-2204:2023.07.2`). This PR fixes subsequent CI commands from failing to be processed by avoiding manipulating `PATH` incorrectly.
 
With an example config like so, commands before `sam/install` will work but anything after - the final `run` step - fails with `Exited with code exit status 127` because the `sam/install` command has adjusted the `PATH` incorrectly to add `/usr/local/bin/sam` as a directory:

```yaml
version: 2.1

orbs:
  aws-cli: circleci/aws-cli@4.0
  sam: circleci/aws-sam-serverless@5.0

jobs:
  test:
    machine:
      image: ubuntu-2204:2023.07.2

    steps:
      - checkout
      - run:
          name: "Git submodule checkout"
          command: |
            git submodule sync
            git submodule update --init --recursive

      - aws-cli/install
      - sam/install
      - run:
          name: This will fail
          command: echo 'Success'

workflows:
  main:
    jobs:
      - test
```

`PATH` should only feature directories; from `man bash`:

> **PATH**   The search path for commands.  It is a colon-separated list of directories in which the shell looks for commands

`/usr/local/bin` is already on the `PATH` as already implicitly tested by line 46 (`which sam`) which would already be failing immediately if `sam` couldn't be found (such as in different execution environments), so this PR simply removes the redundant, breaking line.

```
$ env | grep PATH
PATH=/home/circleci/.go_workspace/bin:/usr/local/go/bin:/opt/google/google-cloud-sdk/bin:/home/circleci/.rbenv/shims:/opt/circleci/.rbenv/bin:/opt/circleci/.pyenv/shims:/home/circleci/.go_workspace/bin:/usr/local/go/bin:/opt/google/google-cloud-sdk/bin:/home/circleci/.rbenv/shims:/opt/circleci/.rbenv/bin:/opt/circleci/.pyenv/bin:/usr/local/apache-maven/bin:/home/circleci/.yarn/bin:/home/circleci/.config/yarn/global/node_modules/.bin:/home/circleci/bin:/home/circleci/.go_workspace/bin:/usr/local/go/bin:/opt/google/google-cloud-sdk/bin:/home/circleci/.rbenv/shims:/opt/circleci/.rbenv/bin:/opt/circleci/.pyenv/bin:/usr/local/apache-maven/bin:/home/circleci/.yarn/bin:/home/circleci/.config/yarn/global/node_modules/.bin:/opt/circleci/.nvm/versions/node/v18.16.1/bin:/home/circleci/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/gradle-8.2/bin:/usr/local/gradle-8.2/bin
```

**Edit:** a workaround until this is merged is that `sam/install` can just be replaced with its raw script:
```yaml
      - run:
          name: Install SAM CLI - workaround
          command: |
            cd /tmp || true
            curl -L "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip" -o aws-sam-cli-linux-x86_64.zip
            unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
            sudo ./sam-installation/install
            sam --version
```