### PR TITLE
fix: multiple arguments

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -65,6 +65,42 @@ workflows:
           context: CPE-OIDC
           filters: *filters
       - sam/deploy:
+          name: deploy-job-test-app-multiline-arguments
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_SAM_SEVERLESS_OIDC_TEST
+                profile_name: OIDC-User
+          profile_name: OIDC-User
+          capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
+          template: "./sample_test/sam-app/template.yaml"
+          stack_name: "orb-deploy-job-test-1"
+          s3_bucket: "sam-orb-testing"
+          arguments: >-
+            --disable-rollback
+            --debug
+          build_container_vars:  Function1.GITHUB_TOKEN=VAR1, GLOBAL_ENV_VAR=VAR2
+          build_arguments: >-
+            --parallel
+            --debug
+          context: CPE-OIDC
+          filters: *filters
+      - sam/deploy:
+          name: deploy-job-test-app-same-line-arguments
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_SAM_SEVERLESS_OIDC_TEST
+                profile_name: OIDC-User
+          profile_name: OIDC-User
+          capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
+          template: "./sample_test/sam-app/template.yaml"
+          stack_name: "orb-deploy-job-test-1"
+          s3_bucket: "sam-orb-testing"
+          arguments: --disable-rollback --debug
+          build_container_vars:  Function1.GITHUB_TOKEN=VAR1, GLOBAL_ENV_VAR=VAR2
+          build_arguments: --parallel --debug
+          context: CPE-OIDC
+          filters: *filters
+      - sam/deploy:
           name: deploy-job-test-container
           auth:
             - aws-cli/setup:
@@ -85,6 +121,13 @@ workflows:
           vcs_type: << pipeline.project.type >>
           pub_type: production
           enable_pr_comment: true
-          requires: [orb-tools/pack, test_local_invoke, deploy-job-test-app, deploy-job-test-container]
+          requires:
+            - orb-tools/pack
+            - test_local_invoke
+            - deploy-job-test-app
+            - deploy-job-test-app-overrides-and-arguments
+            - deploy-job-test-app-multiline-arguments
+            - deploy-job-test-app-same-line-arguments
+            - deploy-job-test-container
           context: orb-publisher
           filters: *release-filters

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -38,7 +38,7 @@ if [ -n "$ORB_STR_BUILD_PARAMETER_OVERRIDES" ]; then
     set -- "$@" --parameter-overrides "${ORB_STR_BUILD_PARAMETER_OVERRIDES}"
 fi
 if [ -n "$ORB_STR_BUILD_ARGUMENTS" ]; then
-    set -- "$@" "${ORB_STR_BUILD_ARGUMENTS}"
+    set -- "$@" ${ORB_STR_BUILD_ARGUMENTS}
 fi
 
 set -x

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -38,6 +38,7 @@ if [ -n "$ORB_STR_BUILD_PARAMETER_OVERRIDES" ]; then
     set -- "$@" --parameter-overrides "${ORB_STR_BUILD_PARAMETER_OVERRIDES}"
 fi
 if [ -n "$ORB_STR_BUILD_ARGUMENTS" ]; then
+    # shellcheck disable=SC2086
     set -- "$@" ${ORB_STR_BUILD_ARGUMENTS}
 fi
 

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -58,6 +58,7 @@ if [ -n "$ORB_STR_OVERRIDES" ]; then
     set -- "$@" --parameter-overrides "${ORB_STR_OVERRIDES}"
 fi
 if [ -n "$ORB_STR_ARGUMENTS" ]; then
+    # shellcheck disable=SC2086
     set -- "$@" $ORB_STR_ARGUMENTS
 fi
 set -x

--- a/src/scripts/deploy.sh
+++ b/src/scripts/deploy.sh
@@ -58,7 +58,7 @@ if [ -n "$ORB_STR_OVERRIDES" ]; then
     set -- "$@" --parameter-overrides "${ORB_STR_OVERRIDES}"
 fi
 if [ -n "$ORB_STR_ARGUMENTS" ]; then
-    set -- "$@" "$ORB_STR_ARGUMENTS"
+    set -- "$@" $ORB_STR_ARGUMENTS
 fi
 set -x
 sam deploy --profile "${ORB_STR_PROFILE_NAME}" "$@"


### PR DESCRIPTION
This pull request fixes an issue with multiple arguments. Currently, if more than one argument is supplied, single quotes are injected around the string, causing the `sam deploy` command to fail. 
