### PR TITLE
Really update machine to current everywhere

### DIFF
--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -5,7 +5,7 @@ executor:
   machine_image: <<parameters.machine_image>>
 parameters:
   machine_image:
-    default: ubuntu-2204:2022.07.1
+    default: ubuntu-2204:current
     type: string
     description: >
       The CircleCI Linux Machine VM Image for this job. Find other available machine images here: https://circleci.com/docs/2.0/configuration-reference/#available-machine_images


### PR DESCRIPTION
The change in 6.0.0. updated the default executor to use the current ubuntu machine image by default, but didn't update the job's machine parameter's default value also (which is passed in to the default executor and overrides the default value that was changed!)

This commit updates the default value of the machine parameter in the job too, ensuring everywhere that a default is used anyhow we always end up with the current ubuntu image rather than a deprecated one.