### PR TITLE
fix: Don't expand $PATH

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,7 +42,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-app/template.yaml"
-          stack_name: "orb-deploy-job-test-1"
+          stack_name: "orb-deploy-job-test-3"
           s3_bucket: "sam-orb-testing"
           context: CPE-OIDC
           filters: *filters
@@ -55,7 +55,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-app/template.yaml"
-          stack_name: "orb-deploy-job-test-1"
+          stack_name: "orb-deploy-job-test-3"
           s3_bucket: "sam-orb-testing"
           parameter_overrides: ParameterKey=dummy,ParameterValue=dummy
           arguments:  --disable-rollback
@@ -73,7 +73,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-app/template.yaml"
-          stack_name: "orb-deploy-job-test-1"
+          stack_name: "orb-deploy-job-test-3"
           s3_bucket: "sam-orb-testing"
           arguments: >-
             --disable-rollback
@@ -93,7 +93,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-app/template.yaml"
-          stack_name: "orb-deploy-job-test-1"
+          stack_name: "orb-deploy-job-test-3"
           s3_bucket: "sam-orb-testing"
           arguments: --disable-rollback --debug
           build_container_vars:  Function1.GITHUB_TOKEN=VAR1, GLOBAL_ENV_VAR=VAR2
@@ -109,7 +109,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-container/template.yaml"
-          stack_name: "orb-deploy-job-test-2"
+          stack_name: "orb-deploy-job-test-4"
           image_repositories: $DEMO_IMG_URI
           context: CPE-OIDC
           validate: false

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -148,7 +148,6 @@ workflows:
           validate: false
           filters: *filters
       - cleanup:
-          name: Delete stacks
           context: CPE-OIDC
           requires:
           - deploy-job-test-container

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,7 +15,7 @@ jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
   test_local_invoke:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:2024.08.1
     steps:
       - checkout
       - aws-cli/setup:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -13,15 +13,6 @@ release-filters: &release-filters
     only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
-  temp-cleanup:
-    docker:
-    - image: cimg/base:stable
-    steps:
-      - aws-cli/setup:
-          role_arn: arn:aws:iam::122211685980:role/CPE_SAM_SEVERLESS_OIDC_TEST
-          profile_name: OIDC-User
-      - run: |
-          aws cloudformation delete-stack --stack-name orb-deploy-job-test-1 --profile OIDC-User
   cleanup:
     docker:
     - image: cimg/base:stable
@@ -49,8 +40,6 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - temp-cleanup:
-          context: CPE-OIDC
       - test_local_invoke:
           context: CPE-OIDC
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -56,8 +56,6 @@ workflows:
           s3_bucket: "sam-orb-testing"
           context: CPE-OIDC
           filters: *filters
-          requires:
-          - temp-cleanup
       - sam/deploy:
           name: deploy-job-test-app-overrides-and-arguments
           auth:
@@ -130,8 +128,6 @@ workflows:
           stack_name: "orb-deploy-job-test-2"
           image_repositories: $DEMO_IMG_URI
           context: CPE-OIDC
-          requires:
-          - temp-cleanup
           validate: false
           filters: *filters
       - cleanup:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,7 +42,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-app/template.yaml"
-          stack_name: "orb-deploy-job-test-3"
+          stack_name: "orb-deploy-job-test-1"
           s3_bucket: "sam-orb-testing"
           context: CPE-OIDC
           filters: *filters
@@ -55,7 +55,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-app/template.yaml"
-          stack_name: "orb-deploy-job-test-3"
+          stack_name: "orb-deploy-job-test-1"
           s3_bucket: "sam-orb-testing"
           parameter_overrides: ParameterKey=dummy,ParameterValue=dummy
           arguments:  --disable-rollback
@@ -73,7 +73,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-app/template.yaml"
-          stack_name: "orb-deploy-job-test-3"
+          stack_name: "orb-deploy-job-test-1"
           s3_bucket: "sam-orb-testing"
           arguments: >-
             --disable-rollback
@@ -93,7 +93,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-app/template.yaml"
-          stack_name: "orb-deploy-job-test-3"
+          stack_name: "orb-deploy-job-test-1"
           s3_bucket: "sam-orb-testing"
           arguments: --disable-rollback --debug
           build_container_vars:  Function1.GITHUB_TOKEN=VAR1, GLOBAL_ENV_VAR=VAR2
@@ -109,7 +109,7 @@ workflows:
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-container/template.yaml"
-          stack_name: "orb-deploy-job-test-4"
+          stack_name: "orb-deploy-job-test-2"
           image_repositories: $DEMO_IMG_URI
           context: CPE-OIDC
           validate: false

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -22,9 +22,6 @@ jobs:
           profile_name: OIDC-User
       - run: |
           aws cloudformation delete-stack --stack-name orb-deploy-job-test-1 --profile OIDC-User
-          aws cloudformation delete-stack --stack-name orb-deploy-job-test-2 --profile OIDC-User
-          aws cloudformation delete-stack --stack-name orb-deploy-job-test-3 --profile OIDC-User
-          aws cloudformation delete-stack --stack-name orb-deploy-job-test-4 --profile OIDC-User
   cleanup:
     docker:
     - image: cimg/base:stable
@@ -152,7 +149,7 @@ workflows:
           context: CPE-OIDC
           requires:
           - deploy-job-test-container
-          - deploy-job-test-app-multiline-arguments
+          - deploy-job-test-app-same-line-arguments
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@12.0
-  aws-cli: circleci/aws-cli@4.0
+  aws-cli: circleci/aws-cli@5.1.1
   sam: {}
 filters: &filters
   tags:
@@ -13,6 +13,28 @@ release-filters: &release-filters
     only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
+  temp-cleanup:
+    docker:
+    - image: cimg/base:stable
+    steps:
+      - aws-cli/setup:
+          role_arn: arn:aws:iam::122211685980:role/CPE_SAM_SEVERLESS_OIDC_TEST
+          profile_name: OIDC-User
+      - run: |
+          aws cloudformation delete-stack --stack-name orb-deploy-job-test-1 --profile OIDC-User
+          aws cloudformation delete-stack --stack-name orb-deploy-job-test-2 --profile OIDC-User
+          aws cloudformation delete-stack --stack-name orb-deploy-job-test-3 --profile OIDC-User
+          aws cloudformation delete-stack --stack-name orb-deploy-job-test-4 --profile OIDC-User
+  cleanup:
+    docker:
+    - image: cimg/base:stable
+    steps:
+      - aws-cli/setup:
+          role_arn: arn:aws:iam::122211685980:role/CPE_SAM_SEVERLESS_OIDC_TEST
+          profile_name: OIDC-User
+      - run: |
+          aws cloudformation delete-stack --stack-name orb-deploy-job-test-1 --profile OIDC-User
+          aws cloudformation delete-stack --stack-name orb-deploy-job-test-2 --profile OIDC-User
   test_local_invoke:
     machine:
       image: ubuntu-2004:2024.08.1
@@ -30,6 +52,7 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
+      - temp-cleanup
       - test_local_invoke:
           context: CPE-OIDC
           filters: *filters
@@ -46,6 +69,8 @@ workflows:
           s3_bucket: "sam-orb-testing"
           context: CPE-OIDC
           filters: *filters
+          requires:
+          - temp-cleanup
       - sam/deploy:
           name: deploy-job-test-app-overrides-and-arguments
           auth:
@@ -54,6 +79,8 @@ workflows:
                 profile_name: OIDC-User
           profile_name: OIDC-User
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
+          requires:
+          - deploy-job-test-app
           template: "./sample_test/sam-app/template.yaml"
           stack_name: "orb-deploy-job-test-1"
           s3_bucket: "sam-orb-testing"
@@ -75,6 +102,8 @@ workflows:
           template: "./sample_test/sam-app/template.yaml"
           stack_name: "orb-deploy-job-test-1"
           s3_bucket: "sam-orb-testing"
+          requires:
+          - deploy-job-test-app-overrides-and-arguments
           arguments: >-
             --disable-rollback
             --debug
@@ -94,6 +123,8 @@ workflows:
           capabilities: CAPABILITY_IAM, CAPABILITY_NAMED_IAM
           template: "./sample_test/sam-app/template.yaml"
           stack_name: "orb-deploy-job-test-1"
+          requires:
+          - deploy-job-test-app-multiline-arguments
           s3_bucket: "sam-orb-testing"
           arguments: --disable-rollback --debug
           build_container_vars:  Function1.GITHUB_TOKEN=VAR1, GLOBAL_ENV_VAR=VAR2
@@ -112,8 +143,16 @@ workflows:
           stack_name: "orb-deploy-job-test-2"
           image_repositories: $DEMO_IMG_URI
           context: CPE-OIDC
+          requires:
+          - temp-cleanup
           validate: false
           filters: *filters
+      - cleanup:
+          name: Delete stacks
+          context: CPE-OIDC
+          requires:
+          - deploy-job-test-container
+          - deploy-job-test-app-multiline-arguments
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -129,5 +168,6 @@ workflows:
             - deploy-job-test-app-multiline-arguments
             - deploy-job-test-app-same-line-arguments
             - deploy-job-test-container
+            - cleanup
           context: orb-publisher
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -52,7 +52,8 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - temp-cleanup
+      - temp-cleanup:
+          context: CPE-OIDC
       - test_local_invoke:
           context: CPE-OIDC
           filters: *filters

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -44,5 +44,6 @@ fi
 unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
 $SUDO ./sam-installation/install
 which sam
-echo "export PATH=$PATH:/usr/local/bin/sam" >>"$BASH_ENV"
+# shellcheck disable=SC2016
+echo 'export PATH=$PATH:/usr/local/bin/sam' >>"$BASH_ENV"
 sam --version


### PR DESCRIPTION
Python installed via pyenv is broken when using this orb.
For example, after installing SAM CLI and execute `python --version`, error occurred with a following message:
> /home/circleci/.pyenv/libexec/pyenv-exec: line 24: pyenv-version-name: command not found

This is because `$PATH` is expanded when writing to `BASH_ENV`,
https://github.com/CircleCI-Public/aws-sam-serverless-orb/blob/7a4f34432e37e985760173873ee196e6c31aa72a/src/scripts/install.sh#L47
and pyenv internally exports `PATH` to use some commands like `python-version-name`. https://github.com/pyenv/pyenv/blob/d64d1aa1e0fa410e58cc218e721eb4c3672ce5bd/libexec/pyenv#L90

To fix this, I changed double quotes to single quotes and suppress `$PATH` expansion.

You can find same kind of issue comments or PRs:
- https://github.com/CircleCI-Public/gcp-cli-orb/issues/22#issuecomment-715463423
- https://github.com/honeycombio/buildevents-orb/pull/98