### PR TITLE
fix: remove incorrect PATH

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -44,6 +44,4 @@ fi
 unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
 $SUDO ./sam-installation/install
 which sam
-# shellcheck disable=SC2016
-echo 'export PATH=$PATH:/usr/local/bin/sam' >>"$BASH_ENV"
 sam --version


### PR DESCRIPTION
Generally, `PATH` is a list of directories, and we cannot add a file directly to `PATH`.

`/usr/local/bin/sam` is not a directory but a file and we don't need to add any directories to `PATH` to use `sam` command.

To be honest, when I submitted #75, I don't care whether `/usr/local/bin/sam` is a directory or not, but actually, response of `which sam`(line 46) is `/usr/local/bin/sam`.